### PR TITLE
Subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Visualize a Hi-C matrix file as a heatmap of contact frequencies. Allows to tune
 
 ### Connecting the modules
 
-All the steps described here are handled automatically when running the `hicstuff pipeline`. But if you want to connect the different modules manually, the intermediary input and output files must be processed using light bash scripting.
+All the steps described here are handled automatically when running the `hicstuff pipeline`. But if you want to connect the different modules manually, the intermediate input and output files must be processed using light bash scripting.
 
 #### Extracting contacts from the alignment
 The output from iteralign is a SAM file. In order to retrieve Hi-C pairs, you need to run iteralign separately on the two fastq files and process the resulting alignment files processed as follows using bedtools and some bash commands.
@@ -230,3 +230,10 @@ cut -f4,9 "$tmp_dir/contact_intersect_sorted.bed" |
   awk '{print $0,$1}' |
   cut -f1 --complement >> matrix.tsv
 ```
+
+### File formats
+
+* 2D BED: This is the input format for `hicstuff filter`. It has one line per Hi-C pair and the following fields for each read: **chr start end name frag_id strand**.
+* 2D bedgraph: This is an optional output format of `hicstuff pipeline` for the sparse matrix. It has two fragment per line, and the number of times they are found together. It has the following fields: **chr1, start1, end1, chr2, start2, end2, occurences**
+
+* GRAAL sparse matrix: This is a simple CSV file with 3 columns: **id_a, id_b, occurrences**. The id columns correspond to the absolute id of the restriction fragments (0-indexed).

--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ or, for the latest version:
 
 ## Usage
 
-### Fastq to contact map pipeline
+### Full pipeline
+
+All components of the pipelines can be run at once using the `hicstuff pipeline` commands. This allows to generate a contact matrix from reads in a single command. By default, the output sparse matrix is in GRAAL format, but it can be a 2D bedgraph file if required.
 
     Usage:
-        yahcp -1 reads_forward.fastq -2 reads_reverse.fastq -f genome.fa [-s size] [-o output_directory] [-e enzyme] [-q quality_min] [--duplicates] [--clean-up]
+        hicstuff pipeline -1 reads_forward.fastq -2 reads_reverse.fastq -f genome.fa [-s size] [-o output_directory] [-e enzyme] [-q quality_min] [--duplicates] [--clean-up]
 
     Options:
         -1 or --forward: Forward FASTQ reads
@@ -50,60 +52,181 @@ or, for the latest version:
          -info_contigs.txt: information about contigs or chromosomes
 
 
-### Contact map visualization
-
-    Usage:
-        vizmap <contact_map> [--binning=1] [--normalize] [--output=<output.png>]
-                                [--max=99]
-
-    Options:
-        -h, --help              Display this help message.
-        --version               Display the program's current version.
-        -b 1, --binning 1       Subsampling factor for binning. [default: 1]
-        -N, --normalize         Normalize the contact map prior to binning.
-                                [default: False]
-        -o file, --output file  Save image to output instead of plotting it.
-                                [default: output.png]
-          -m 99, --max 99         Saturation percentile threshold in the contact map.
-                                  [default: 99]
-
-  ### Iterative mapping
-
-  ### Filtering 3C events
-
-    usage: filter3C.py [-h] [-i | -t THRESHOLDS THRESHOLDS] -F FRAGS [-p]
-                       input_file [output_file]
-
-    positional arguments:
-      input_file            The 2D BED file containing the coordinates of Hi-C
-                            interacting pairs and, the indices of their
-                            restriction fragments and their strands.
-      output_file           Path to the output file (filtered dat.indices).
-                            Defaults to stdout.
-
-    optional arguments:
-      -h, --help            show this help message and exit
-      -i, --interactive     Interactively shows plots and asks the user for
-                            thresholds. Overrides predefined thresholds. Disabled
-                            by default.
-      -t THRESHOLDS THRESHOLDS, --thresholds THRESHOLDS THRESHOLDS
-                            The minimum number of restriction fragments between
-                          reads to consider loops and uncut events. Estimated
-                          automatically by default. Must be two integers
-                          separated by a space (-t <loop> <uncut>).
-    -F FRAGS, --frags FRAGS
-                          Path to bed file containing the sorted list of
-                          fragments, with fields: chr start end.
-    -p, --plot_summary    Output a piechart summarizing library composition.
-
-
 ### Library
 
-See the documentation on [reathedocs](https://hicstuff.readthedocs.io). The expected contact map format for the library is a simple CSV file, and the objects handled by the library are simple ```numpy``` arrays.
+All components of the hicstuff program can be used as python modules. See the documentation on [reathedocs](https://hicstuff.readthedocs.io). The expected contact map format for the library is a simple CSV file, and the objects handled by the library are simple ```numpy``` arrays.
 
 
-### Individual components
+### Individual pipeline components
 
-Different scripts can be used independently to perform individual parts of the pipeline.
+For more advanced usage, different scripts can be used independently on the command line to perform individual parts of the pipeline.
 
-#### Event filtering
+#### Iterative alignment
+Truncate reads from a fastq file to 20 basepairs and iteratively extend and re-align the unmapped reads to optimize the proportion of uniquely aligned reads in a 3C library.
+
+    usage:
+        hicstuff iteralign [--minimap2] [--threads=1] [--min_len=20] --out_sam=FILE --fasta=FILE <reads.fq>
+
+    arguments:
+        reads.fq                Fastq file containing the reads to be aligned
+
+    options:
+        -f FILE, --fasta=FILE   Fasta file on which to map the reads.
+        -t INT, --threads=INT  Number of parallel threads allocated for the alignment [default: 1].
+        -T DIR, --tempdir=DIR  Temporary directory. Defaults to current directory.
+        -m, --minimap2     If set, use minimap2 instead of bowtie2 for the alignment.
+        -l INT, --min_len=INT  Length to which the reads should be truncated [default: 20].
+        -o FILE, --out_sam=FILE Path where the alignment will be written in SAM format.
+
+
+#### Digestion of the genome
+
+Digests a fasta file into fragments based on a restriction enzyme or a
+fixed chunk size. Generates two output files into the target directory
+named "info_contigs.txt" and "fragments_list.txt"
+
+    usage:
+        digest --enzyme=ENZYME [--size=INT] [--outdir DIR] [--circular] <fasta>
+
+    arguments:
+        fasta                     Fasta file to be digested
+
+    options:
+        -c, --circular           Whether the genome is circular.
+        -e ENZ, --enzyme=ENZ     A restriction enzyme or an integer representing chunk sizes (in bp)
+        -s INT, --size=INT       Minimum size threshold to keep fragments [default: 0]
+        -o DIR, --outdir=DIR     Directory where the fragments and contigs files will be written
+
+    output:
+        -fragments_list.txt: information about restriction fragments (or chunks)
+        -info_contigs.txt: information about contigs or chromosomes
+
+
+#### Filtering of 3C events
+
+Filters spurious 3C events such as loops and uncuts from the library based
+on a minimum distance threshold automatically estimated from the library by default. Can also plot 3C library statistics.
+
+    usage:
+        hicstuff filter [--interactive | --thresholds INT,INT] [--plot_summary] <input> <output>
+
+    arguments:
+        input       2D BED file containing coordinates of Hi-C interacting pairs,
+                    the index of their restriction fragment and their strands.
+        output      Path to the filtered file, in the same format as the input.
+
+    options:
+        -F FILE, --frags=FILE             BED file containing digested genome fragments
+        -i, --interactive                 Interactively shows plots and asks for thresholds.
+        -t INT-INT, --thresholds=INT-INT  Manually defines integer values for the thresholds in the order [uncut, loop].
+        -p, --plot_summary                If set, a plot with library composition informations will be displayed.
+
+
+#### Viewing the contact map
+
+Visualize a Hi-C matrix file as a heatmap of contact frequencies. Allows to tune visualisation by binning and normalizing the matrix, and to save the output image to disk. If no output is specified, the output is displayed.
+
+    usage:
+        hicstuff view [--binning=1] [--normalize] [--max=99] [--output=IMG] <contact_map>
+
+    arguments:
+        contact_map             Sparse contact matrix in GRAAL format
+
+    options:
+        -b INT, --binning=INT   Subsampling factor to use for binning [default: 1].
+        -n, --normalize         Should SCN normalization be performed before rendering the matrix ?
+        -m INT, --max=INT       Saturation threshold. Maximum pixel value is set to this percentile [default: 99].
+        -o IMG, --output=IMG    Path where the matrix will be stored in PNG format.
+
+### Connecting the modules
+
+All the steps described here are handled automatically when running the `hicstuff pipeline`. But if you want to connect the different modules manually, the intermediary input and output files must be processed using light bash scripting.
+
+#### Extracting contacts from the alignment
+The output from iteralign is a SAM file. In order to retrieve Hi-C pairs, you need to run iteralign separately on the two fastq files and process the resulting alignment files processed as follows using bedtools and some bash commands.
+
+1. Convert the SAM files into BED format
+
+```bash
+samtools view -bS -F 260 -@ $t -q 30 "for.sam" |
+  bedtools bamtobed -i - |
+  awk 'OFS="\t" { print $1,$2,$3,$4,$6 }' \
+    > contacts_for.bed
+
+samtools view -bS -F 260 -@ $t -q 30 "rev.sam" |
+  bedtools bamtobed -i - |
+  awk 'OFS="\t" { print $1,$2,$3,$4,$6 }' \
+    > contacts_rev.bed
+```
+
+2. Put all forward and reverse reads into a single sorted BED file
+
+```bash
+sort -k1,1d -k2,2n contacts_for.bed contacts_rev.bed \
+  > total_contacts.bed
+
+```
+
+#### Attributing each read to a restriction fragment
+To build a a contact matrix, we need to attribute each read to a fragment in the genome. This is done by intersecting all the reads with the digested genome.
+
+1. Extract restriction fragments from the genome using `hicstuff digest`.
+
+```bash
+# Generate fragments_list.txt
+hicstuff digest --fasta genome.fa \
+  --enzyme DpnII \
+  --output-dir .
+
+# Make a BED from it
+awk 'NR>1 { print $2"\t"$3"\t"$4"\t"(NR-2) }' fragments_list.txt
+  >fragments_list.bed
+
+```
+
+2. Intersect the BED files of reads and restriction fragments.
+
+```bash
+bedtools intersect -a total_contacts.bed \
+  -b fragments_list.bed -wa -wb |
+  sort -k4d  \
+  > contact_intersect_sorted.bed
+
+```
+4. Get reads into a paired BED file (1 pair per line)
+
+```bash
+# Note: F is fragment and R is read
+# This awk snippet allows to convert a sorted BED file with fields:
+#   Rchr Rstart Rend Rname Rstrand Fchr Fstart Fend Fidx
+# to a "2D BED" file with:
+#   F1chr F1start F1end F1idx R1strand F2chr F2start F2end F2idx R2strand
+bed2pairs='
+BEGIN{dir="for"; OFS="\t"}
+{
+  if(dir=="for") {
+    fw["name"]=$4; fw["coord"]=$6"\t"$7"\t"$8"\t"$9"\t"$5; dir="rev" }
+  else {
+    if(fw["name"] == $4) {
+        print fw["coord"],$6,$7,$8,$9,$5; dir="for"}
+    else {
+        dir="rev"; fw["coord"]=$6"\t"$7"\t"$8"\t"$9"\t"$5; fw["name"]=$4}
+    }
+}
+'
+awk "$bed2pairs" > contact_intersect_sorted.bed2D
+```
+The resulting 2D BED file can then be filtered by the `hicstuff filter` module if needed, otherwise, the matrix can be built directly from it. To generate a GRAAL-compatible sparse matrix from the 2D bed file:
+
+```bash
+# Remove strand information, sort by fragment combination,
+# Count occurrences of each fragment combination and format into csv.
+echo -e "id_fragment_a\tid_fragment_b\tn_contact" > matrix.tsv
+cut -f4,9 "$tmp_dir/contact_intersect_sorted.bed" |
+  sort -V |
+  uniq -c |
+  sed 's/^\s*//' |
+  tr ' ' '\t' |
+  awk '{print $0,$1}' |
+  cut -f1 --complement >> matrix.tsv
+```

--- a/hicstuff/commands.py
+++ b/hicstuff/commands.py
@@ -2,8 +2,15 @@
 # https://github.com/rgreinho/docopt-subcommands-example
 # cmdoret, 20181412
 from docopt import docopt
-import hicstuff
+from hicstuff.hicstuff import bin_sparse, normalize_sparse, bin_kb_sparse
+from hicstuff.iteralign import *
+from hicstuff.fraglist import write_frag_info, write_sparse_matrix
+from hicstuff.filter import get_thresholds, filter_events, process_read_pair
+from hicstuff.vizmap import load_raw_matrix, raw_cols_to_sparse, sparse_to_dense, plot_matrix
+from re import findall
 import sys
+import shutil as st
+import pdb
 
 
 class AbstractCommand:
@@ -13,6 +20,7 @@ class AbstractCommand:
 
     def __init__(self, command_args, global_args):
         """Initialize the commands"""
+        print(command_args, global_args)
         self.args = docopt(self.__doc__, argv=command_args)
         self.global_args = global_args
 
@@ -21,28 +29,189 @@ class AbstractCommand:
         raise NotImplementedError
 
 
-class Digest(AbstractCommand):
+class Iteralign(AbstractCommand):
     """
-    Digests a fasta file into fragments.
+    Truncate reads from a fastq file to 20 basepairs and iteratively extend and
+    re-align the unmapped reads to optimize the proportion of uniquely aligned
+    reads in a 3C library.
 
     usage:
-        digest --fasta FILE --ezyme ENZYME [--size SIZE]
+        hicstuff iteralign [--minimap2] [--threads=1] [--min_len=20] --out_sam=FILE --fasta=FILE <reads.fq>
+
+    arguments:
+        reads.fq                Fastq file containing the reads to be aligned
 
     options:
-        --fasta      Fasta file to be digested
-        --enzyme     A restriction enzyme or an integer representing chunk sizes (in bp)
-        --size       Minimum size threshold to keep fragments
-        --output
+        -f FILE, --fasta=FILE   Fasta file on which to map the reads.
+        -t INT,  --threads=INT  Number of parallel threads allocated for the alignment [default: 1].
+        -T DIR,  --tempdir=DIR  Temporary directory. Defaults to current directory.
+        -m,      --minimap2     If set, use minimap2 instead of bowtie2 for the alignment.
+        -l INT,  --min_len=INT  Length to which the reads should be truncated [default: 20].
+        -o FILE, --out_sam=FILE Path where the alignment will be written in SAM format.
+    """
+
+    def execute(self):
+        if not self.args["--tempdir"]:
+            self.args["--tempdir"] = "."
+        if not self.args["--minimap2"]:
+            self.args["--minimap2"] = False
+        temp_directory = generate_temp_dir(self.args["--tempdir"])
+        iterative_align(
+            self.args["<reads.fq>"],
+            self.args["--tempdir"],
+            self.args["--fasta"],
+            self.args["--threads"],
+            self.args["--out_sam"],
+            self.args["--minimap2"],
+        )
+        # Deletes the temporary folder
+        st.rmtree(temp_directory)
+
+
+class Digest(AbstractCommand):
+    """
+    Digests a fasta file into fragments based on a restriction enzyme or a
+    fixed chunk size. Generates two output files: info_contigs.txt and fragments_list.txt
+
+    usage:
+        hicstuff digest --enzyme ENZYME [--size=INT] [--outdir DIR] <fasta>
+
+    arguments:
+        fasta                     Fasta file to be digested
+
+    options:
+        -e ENZ,  --enzyme=ENZ     A restriction enzyme or an integer representing chunk sizes (in bp)
+        -s INT,  --size=INT       Minimum size threshold to keep fragments [default: 0]
+        -o DIR,  --outdir=DIR     Directory where the fragments and contigs files will be written
     """
 
     def execute(self):
         if not self.args["--size"]:
             self.args["--size"] = 0
         if not self.args["--output"]:
-            self.args["--output"] = sys.stderr
-        hicstuff.fraglist(
+            self.args["--output"] = sys.stdout
+        write_frag_info(
             self.args["--fasta"],
             self.args["--enzyme"],
             self.args["--size"],
             output_frags=self.args["--output"],
         )
+
+
+class Filter(AbstractCommand):
+    """
+    Filters spurious 3C events such as loops and uncuts from the library based
+    on a minimum distance threshold automatically estimated from the library by
+    default. Can also plot 3C library statistics.
+
+    usage:
+        hicstuff filter [--interactive | --thresholds INT,INT] [--plot_summary] <input> <output>
+
+    arguments:
+        input       2D BED file containing coordinates of Hi-C interacting pairs,
+                    the index of their restriction fragment and their strands.
+        output      Path to the filtered file, in the same format as the input.
+
+    options:
+        -F FILE,    --frags=FILE          BED file containing digested genome fragments
+        -i,         --interactive         Interactively shows plots and asks for thresholds.
+        -t INT-INT, --thresholds=INT-INT  Manually defines integer values for the thresholds in the order [uncut, loop].
+        -p,         --plot_summary        If set, a plot with library composition informations will be displayed.
+    """
+
+    def execute(self):
+        output_handle = open(self.args["<output>"], "w")
+        if self.args["--thresholds"]:
+            # Thresholds supplied by user beforehand
+            uncut_thr, loop_thr = self.args["--thresholds"].split("-")
+        else:
+            # Threshold defined at runtime
+            with open(self.args["<input_file>"]) as handle_in:
+                uncut_thr, loop_thr = get_thresholds(
+                    handle_in, interactive=self.args["--interactive"]
+                )
+        # Filter library and write to output file
+        with open(args.input_file) as handle_in:
+            filter_events(
+                handle_in,
+                output_handle,
+                uncut_thr,
+                loop_thr,
+                plot_events=self.args["--plot_summary"],
+            )
+
+
+class View(AbstractCommand):
+    """
+    Visualize a Hi-C matrix file as a heatmap of contact frequencies. Allows to
+    tune visualisation by binning and normalizing the matrix, and to save the
+    output image to disk. If no output is specified, the output is displayed.
+
+    usage:
+        hicstuff view [--binning=1] [--normalize] [--max=99] [--output=IMG] <contact_map>
+
+    arguments:
+        contact_map             Sparse contact matrix in GRAAL or 2D bedgraph format
+
+    options:
+        -b INT, --binning=INT   Subsampling factor to use for binning [default: 1].
+        -n,     --normalize     Should SCN normalization be performed before rendering the matrix ?
+        -m INT, --max=INT       Saturation threshold. Maximum pixel value is set to this percentile [default: 99].
+        -o IMG, --output=IMG    Path where the matrix will be stored in PNG format.
+    """
+
+    def execute(self):
+
+        input_map = self.args["<contact_map>"]
+        binsuffix = {"bp": 1, "kb": 1000, "Mb": 1_000_000}
+        try:
+            binning = int(self.args["--binning"])
+        except ValueError:
+            print("Please provide an integer for binning.", file=sys.stderr)
+            raise
+
+        normalized = self.args["--normalize"]
+        vmax = float(self.args["--max"])
+
+        output_file = self.args["--output"]
+
+        raw_map = load_raw_matrix(input_map)
+
+        sparse_map = raw_cols_to_sparse(raw_map)
+
+        if normalized:
+            sparse_map = normalize_sparse(sparse_map, norm="SCN")
+
+        if binning > 1:
+            binned_map = bin_sparse(M=sparse_map, subsampling_factor=binning)
+        else:
+            binned_map = sparse_map
+
+        try:
+            dense_map = sparse_to_dense(binned_map)
+            plot_matrix(dense_map, filename=output_file, vmax=vmax)
+        except MemoryError:
+            print("Contact map is too large to load, try binning more")
+
+
+class Pipeline(AbstractCommand):
+    """
+    Entire Pipeline to process fastq files into a Hi-C matrix. Uses all the individual components of hicstuff.
+
+    usage:
+        hicstuff pipeline --fasta FILE --enzyme ENZYME [--size SIZE] [--outdir DIR] <fq1> <fq2>
+
+    arguments:
+        fq1:             Forward fastq file
+        fq2:             Reverse fastq file
+
+    options:
+        -f, --fasta      Fasta file to be digested
+        -e, --enzyme     A restriction enzyme or an integer representing chunk sizes (in bp)
+        -s, --size       Minimum size threshold to keep fragments
+        -o, --outdir     Directory where the fragments and contigs files will be written
+    """
+
+    # WIP: Parse arguments in docopt instead of Bash ?
+    def execute(self):
+        pass

--- a/hicstuff/commands.py
+++ b/hicstuff/commands.py
@@ -1,0 +1,48 @@
+# Based on Rémy Greinhofer (rgreinho) tutorial on subcommands in docopt
+# https://github.com/rgreinho/docopt-subcommands-example
+# cmdoret, 20181412
+from docopt import docopt
+import hicstuff
+import sys
+
+
+class AbstractCommand:
+    """
+    Base class for the commands
+    """
+
+    def __init__(self, command_args, global_args):
+        """Initialize the commands"""
+        self.args = docopt(self.__doc__, argv=command_args)
+        self.global_args = global_args
+
+    def execute(self):
+        """Execute the commands"""
+        raise NotImplementedError
+
+
+class Digest(AbstractCommand):
+    """
+    Digests a fasta file into fragments.
+
+    usage:
+        digest --fasta FILE --ezyme ENZYME [--size SIZE]
+
+    options:
+        --fasta      Fasta file to be digested
+        --enzyme     A restriction enzyme or an integer representing chunk sizes (in bp)
+        --size       Minimum size threshold to keep fragments
+        --output
+    """
+
+    def execute(self):
+        if not self.args["--size"]:
+            self.args["--size"] = 0
+        if not self.args["--output"]:
+            self.args["--output"] = sys.stderr
+        hicstuff.fraglist(
+            self.args["--fasta"],
+            self.args["--enzyme"],
+            self.args["--size"],
+            output_frags=self.args["--output"],
+        )

--- a/hicstuff/commands.py
+++ b/hicstuff/commands.py
@@ -35,17 +35,17 @@ class Iteralign(AbstractCommand):
     reads in a 3C library.
 
     usage:
-        hicstuff iteralign [--minimap2] [--threads=1] [--min_len=20] --out_sam=FILE --fasta=FILE <reads.fq>
+        iteralign [--minimap2] [--threads=1] [--min_len=20] --out_sam=FILE --fasta=FILE <reads.fq>
 
     arguments:
         reads.fq                Fastq file containing the reads to be aligned
 
     options:
         -f FILE, --fasta=FILE   Fasta file on which to map the reads.
-        -t INT,  --threads=INT  Number of parallel threads allocated for the alignment [default: 1].
-        -T DIR,  --tempdir=DIR  Temporary directory. Defaults to current directory.
-        -m,      --minimap2     If set, use minimap2 instead of bowtie2 for the alignment.
-        -l INT,  --min_len=INT  Length to which the reads should be truncated [default: 20].
+        -t INT, --threads=INT  Number of parallel threads allocated for the alignment [default: 1].
+        -T DIR, --tempdir=DIR  Temporary directory. Defaults to current directory.
+        -m, --minimap2     If set, use minimap2 instead of bowtie2 for the alignment.
+        -l INT, --min_len=INT  Length to which the reads should be truncated [default: 20].
         -o FILE, --out_sam=FILE Path where the alignment will be written in SAM format.
     """
 
@@ -84,6 +84,10 @@ class Digest(AbstractCommand):
         -e ENZ, --enzyme=ENZ     A restriction enzyme or an integer representing chunk sizes (in bp)
         -s INT, --size=INT       Minimum size threshold to keep fragments [default: 0]
         -o DIR, --outdir=DIR     Directory where the fragments and contigs files will be written
+    output:
+        -fragments_list.txt: information about restriction fragments (or chunks)
+        -info_contigs.txt: information about contigs or chromosomes
+
     """
 
     def execute(self):
@@ -107,7 +111,7 @@ class Filter(AbstractCommand):
     default. Can also plot 3C library statistics.
 
     usage:
-        hicstuff filter [--interactive | --thresholds INT,INT] [--plot_summary] <input> <output>
+        filter [--interactive | --thresholds INT,INT] [--plot_summary] <input> <output>
 
     arguments:
         input       2D BED file containing coordinates of Hi-C interacting pairs,
@@ -150,10 +154,10 @@ class View(AbstractCommand):
     output image to disk. If no output is specified, the output is displayed.
 
     usage:
-        hicstuff view [--binning=1] [--normalize] [--max=99] [--output=IMG] <contact_map>
+        view [--binning=1] [--normalize] [--max=99] [--output=IMG] <contact_map>
 
     arguments:
-        contact_map             Sparse contact matrix in GRAAL or 2D bedgraph format
+        contact_map             Sparse contact matrix in GRAAL format
 
     options:
         -b INT, --binning=INT   Subsampling factor to use for binning [default: 1].
@@ -172,7 +176,6 @@ class View(AbstractCommand):
             print("Please provide an integer for binning.", file=sys.stderr)
             raise
 
-        normalized = self.args["--normalize"]
         vmax = float(self.args["--max"])
 
         output_file = self.args["--output"]
@@ -181,7 +184,7 @@ class View(AbstractCommand):
 
         sparse_map = raw_cols_to_sparse(raw_map)
 
-        if normalized:
+        if self.args["--normalize"]:
             sparse_map = normalize_sparse(sparse_map, norm="SCN")
 
         if binning > 1:
@@ -201,7 +204,7 @@ class Pipeline(AbstractCommand):
     Entire Pipeline to process fastq files into a Hi-C matrix. Uses all the individual components of hicstuff.
 
     usage:
-        hicstuff pipeline --fasta FILE --enzyme ENZYME [--size SIZE] [--outdir DIR] <fq1> <fq2>
+        pipeline --fasta FILE --enzyme ENZYME [--size SIZE] [--outdir DIR] <fq1> <fq2>
 
     arguments:
         fq1:             Forward fastq file

--- a/hicstuff/filter.py
+++ b/hicstuff/filter.py
@@ -26,59 +26,6 @@ import pysam as ps
 import os
 
 
-def parse_args():
-    """ Gets the arguments from the command line."""
-    parser = argparse.ArgumentParser()
-    group = parser.add_mutually_exclusive_group()
-    parser.add_argument(
-        "input_file",
-        type=str,
-        help="The 2D BED file containing the coordinates of Hi-C interacting "
-        "pairs and, the indices of their restriction fragments and their strands.",
-    )
-    parser.add_argument(
-        "output_file",
-        type=str,
-        nargs="?",
-        help="Path to the output file (filtered dat.indices). Defaults to stdout.",
-    )
-    group.add_argument(
-        "-i",
-        "--interactive",
-        action="store_true",
-        required=False,
-        help="Interactively shows plots and asks the user for thresholds. "
-        "Overrides predefined thresholds. Disabled by default.",
-    )
-    group.add_argument(
-        "-t",
-        "--thresholds",
-        nargs=2,
-        type=int,
-        required=False,
-        help="The minimum number of restriction fragments between reads to "
-        "consider loops and uncut events. Estimated automatically by default. "
-        "Must be two integers separated by a space (-t <loop> <uncut>).",
-    )
-    parser.add_argument(
-        "-F",
-        "--frags",
-        type=str,
-        required=True,
-        help="Path to bed file containing the sorted list of fragments, with "
-        "fields: chr start end.",
-    )
-    parser.add_argument(
-        "-p",
-        "--plot_summary",
-        required=False,
-        action="store_true",
-        default=False,
-        help="Output a piechart summarizing library composition.",
-    )
-    return parser.parse_args()
-
-
 def process_read_pair(line):
     """
     Takes a read pair (line) from a 2D BED file as input, reorders the pair

--- a/hicstuff/fraglist.py
+++ b/hicstuff/fraglist.py
@@ -36,7 +36,6 @@ def write_frag_info(
     """Write the fragments_list.txt and info_contigs.txt that are necessary
     for GRAAL to run
     """
-
     try:
         my_enzyme = RestrictionBatch([enzyme]).get(enzyme)
     except ValueError:

--- a/hicstuff/main.py
+++ b/hicstuff/main.py
@@ -7,24 +7,28 @@ Simple Hi-C pipeline for generating and manipulating contact matrices.
 
 usage:
     hicstuff [-hv] <command> [<args>...]
+
 options:
     -h, --help                  shows the help
     -v, --version               shows the version
+
 The subcommands are:
-    filter      filters Hi-C pairs to exclude spurious events
-    digest      digest genome into a list of fragments
     iteralign   iteratively aligns reads to a reference genome
+    digest      digest genome into a list of fragments
+    filter      filters Hi-C pairs to exclude spurious events
     view        visualize a Hi-C matrix
     pipeline    Hi-C pipeline to generate contact matrix from fastq files
 """
 
 from docopt import docopt
 from docopt import DocoptExit
+import pdb
+import hicstuff.commands as commands
+from hicstuff.version import __version__
 
-import commands
 
-if __name__ == "__main__":
-    args = docopt(__doc__, version="1.0.0", options_first=True)
+def main():
+    args = docopt(__doc__, version=__version__, options_first=True)
     # Retrieve the command to execute.
     command_name = args.pop("<command>").capitalize()
 
@@ -42,9 +46,11 @@ if __name__ == "__main__":
     except AttributeError:
         print("Unknown command.")
         raise DocoptExit()
-
     # Create an instance of the command.
-    command = command_lass(command_args, args)
-
+    command = command_class(command_args, args)
     # Execute the command.
     command.execute()
+
+
+if __name__ == "__main__":
+    main()

--- a/hicstuff/main.py
+++ b/hicstuff/main.py
@@ -36,7 +36,6 @@ def main():
     command_args = args.pop("<args>")
     if command_args is None:
         command_args = {}
-
     # After 'popping' '<command>' and '<args>', what is left in the
     # args dictionary are the global arguments.
 

--- a/hicstuff/main.py
+++ b/hicstuff/main.py
@@ -1,0 +1,50 @@
+#! /usr/bin/env python
+# Based on Rémy Greinhofer (rgreinho) tutorial on subcommands in docopt
+# https://github.com/rgreinho/docopt-subcommands-example
+# cmdoret, 20181214
+"""
+Simple Hi-C pipeline for generating and manipulating contact matrices.
+
+usage:
+    hicstuff [-hv] <command> [<args>...]
+options:
+    -h, --help                  shows the help
+    -v, --version               shows the version
+The subcommands are:
+    filter      filters Hi-C pairs to exclude spurious events
+    digest      digest genome into a list of fragments
+    iteralign   iteratively aligns reads to a reference genome
+    view        visualize a Hi-C matrix
+    pipeline    Hi-C pipeline to generate contact matrix from fastq files
+"""
+
+from docopt import docopt
+from docopt import DocoptExit
+
+import commands
+
+if __name__ == "__main__":
+    args = docopt(__doc__, version="1.0.0", options_first=True)
+    # Retrieve the command to execute.
+    command_name = args.pop("<command>").capitalize()
+
+    # Retrieve the command arguments.
+    command_args = args.pop("<args>")
+    if command_args is None:
+        command_args = {}
+
+    # After 'popping' '<command>' and '<args>', what is left in the
+    # args dictionary are the global arguments.
+
+    # Retrieve the class from the 'commands' module.
+    try:
+        command_class = getattr(commands, command_name)
+    except AttributeError:
+        print("Unknown command.")
+        raise DocoptExit()
+
+    # Create an instance of the command.
+    command = command_lass(command_args, args)
+
+    # Execute the command.
+    command.execute()

--- a/hicstuff/vizmap.py
+++ b/hicstuff/vizmap.py
@@ -73,11 +73,11 @@ def plot_matrix(array, filename, vmax=None, dpi=DEFAULT_DPI):
 
     if vmax is None:
         vmax = np.percentile(array, DEFAULT_SATURATION_THRESHOLD)
-    plt.gca().set_axis_off()
-    plt.subplots_adjust(top=1, bottom=0, right=1, left=0, hspace=0, wspace=0)
-    plt.margins(0, 0)
-    plt.gca().xaxis.set_major_locator(plt.NullLocator())
-    plt.gca().yaxis.set_major_locator(plt.NullLocator())
+    # plt.gca().set_axis_off()
+    # plt.subplots_adjust(top=1, bottom=0, right=1, left=0, hspace=0, wspace=0)
+    # plt.margins(0, 0)
+    # plt.gca().xaxis.set_major_locator(plt.NullLocator())
+    # plt.gca().yaxis.set_major_locator(plt.NullLocator())
     plt.figure()
     if SEABORN:
         sns.heatmap(array, vmax=vmax, cmap="Reds")
@@ -88,7 +88,8 @@ def plot_matrix(array, filename, vmax=None, dpi=DEFAULT_DPI):
     if filename:
         plt.savefig(filename, bbox_inches="tight", pad_inches=0.0, dpi=dpi)
         del filename
-    plt.close()
+    else:
+        plt.show()
 
 
 def normalize(M, norm="SCN"):

--- a/scripts/yahcp
+++ b/scripts/yahcp
@@ -7,7 +7,6 @@
 #it relies on to perform some of the GRAAL-specific stuff like matrix/fragment data
 #file generation.
 
-current_dir="$(cd "$(dirname "$0")" && pwd)"
 arguments=()
 # default output filenames
 frag_out="fragments_list.txt"
@@ -18,8 +17,8 @@ trigger_help=0
 
 #Defaults
 enzyme=5000
-output_dir=$current_dir
 quality_min=30
+output_dir="."
 bedgraph=0
 size=0
 duplicate=0
@@ -131,49 +130,6 @@ set -o pipefail
 
 set -- "${arguments[@]}"
 
-#Hopefully useful help message if one of the mandatory parameters is missing
-if [ -z "$reads_for" ] || [ -z "$reads_rev" ] || [ -z "$fasta" ] || [ "$trigger_help" -eq 1 ]; then
-  echo """
-       yahcp (Yet Another Hi-C Pipeline) - A simple and relatively painless Hi-C data processing pipeline
-
-       Usage: yachp -1 reads_forward.fastq -2 reads_reverse.fastq -f genome.fa [-s size] [-o output_directory] [-e enzyme] [-q quality_min] [--duplicates] [--clean-up] [--filter] [--bedgraph]
-
-       Generate a sparse, GRAAL-compatible contact map from paired-end reads and a reference genome (for more information about GRAAL, see https://github.com/koszullab/GRAAL).
-       The map can also be easily visualized with HiC-Box (see https://github.com/koszullab/HiC-Box).
-       Information about fragments and contigs/chromosomes are stored in separate files.
-       The genome can either be partitioned by restriction fragments (specifying the enzyme) or fixed size chunks (specifying a number).
-
-       Requires bowtie2, samtools, bedtools and python (with Biopython installed) to run. Optionally, minimap2 can be used instead of bowtie2 if specified.
-
-       Parameters:
-
-           -1 or --forward: Forward FASTQ reads
-           -2 or --reverse: Reverse FASTQ reads
-           -f or --fasta: Reference genome to map against in FASTA format
-           -o or --output: Output directory. Defaults to the current directory.
-           -P or --prefix: Overrides default GRAAL-compatible filenames and use a prefix with extensions instead.
-           -e or --enzyme: Restriction enzyme if a string, or chunk size (i.e. resolution) if a number. Defaults to 5000 bp chunks.
-           -q or --quality-min: Minimum mapping quality for selecting contacts. Defaults to 30.
-           -d or --duplicates: If enabled, trims (10bp) adapters and PCR duplicates prior to mapping. Not enabled by default.
-           -s or --size: Minimum size threshold to consider contigs. Defaults to 0 (keep all contigs).
-           -n or --no-clean-up: If enabled, intermediary BED files will be kept after generating the contact map. Disabled by defaut.
-           -b or --bedgraph: If enabled, generates a sparse matrix in 2D Bedgraph format (cooler-compatible) instead of GRAAL-compatible format.
-           -P or --prefix: Overrides default GRAAL filenames and use a prefix with extensions instead. Only works in combination with -b.
-           -t or --threads: Number of threads to use for the aligner and samtools. Defaults to 1.
-           -T or --tmp: Directory for storing intermediary BED files and temporary sort files. Defaults to the output directory.
-           -m or --minimap: Use the minimap2 aligner instead of bowtie2. Not enabled by default.
-           -i or --iterative: Map reads iteratively, by truncating reads to 20bp and then repeatedly extending and aligning them.
-           -F or --filter: Filter out spurious 3C events (loops and uncuts). Requires -e to be a restriction enzyme, not a chunk size.
-           -h or --help: Display this help message.
-
-       The expected files in the output directory will take the form:
-           -abs_fragments_contacts_weighted.txt: the sparse contact map
-           -fragments_list.txt: information about restriction fragments (or chunks)
-           -info_contigs.txt: information about contigs or chromosomes
-    """
-  exit 1
-fi
-
 # Check everything's in place
 python3 -c "import Bio" >/dev/null 2>&1 || {
   echo "Error! Biopython is missing from your python libraries. Please install it (using either your package manager or pip)"
@@ -205,8 +161,7 @@ mkdir -p "$tmp_dir"
 
 # Write fragments_list.txt info_contigs.txt
 echo "Writing fragment information..."
-hicstuff digest --fasta "$fasta" --enzyme "$enzyme" \
-  --output-dir "$output_dir" --size "$size""$circular"
+hicstuff digest $circular --enzyme "$enzyme" --outdir "$output_dir" --size "$size" "$fasta"
 
 # Remove adapters and PCR duplicates
 if [ $duplicate -eq 1 ]; then
@@ -351,10 +306,6 @@ else
     mv "${output_dir}/${matrix_out}" "${output_dir}/${prefix}.mat.bg2"
   fi
 fi
-
-# fraglist --intersection "$tmp_dir"/contact_intersect_sorted.bed \
-#  --frags "$output_dir"/fragments_list.txt \
-#  --output-dir "$output_dir"
 
 if [ $clean_up -eq 1 ]; then
   rm "$sam_for" "$sam_rev"

--- a/scripts/yahcp
+++ b/scripts/yahcp
@@ -205,7 +205,7 @@ mkdir -p "$tmp_dir"
 
 # Write fragments_list.txt info_contigs.txt
 echo "Writing fragment information..."
-fraglist --fasta "$fasta" --enzyme "$enzyme" \
+hicstuff digest --fasta "$fasta" --enzyme "$enzyme" \
   --output-dir "$output_dir" --size "$size""$circular"
 
 # Remove adapters and PCR duplicates
@@ -234,7 +234,7 @@ echo "Performing alignment and generating bed files..."
 if [ $iterative -eq 1 ]; then
   # Conditionaly append minimap option flag to command
   [ $minimap -eq 1 ] && miniflag="-m"
-  map_cmd() { iteralign -r "$fasta" -p $t -o $2 -T "$tmp_dir" "$miniflag" $1; }
+  map_cmd() { hicstuff iteralign -f "$fasta" -t $t -o $2 -T "$tmp_dir" "$miniflag" $1; }
 else
   if [ $minimap -eq 0 ]; then
     #Build fasta index files if they don't exist

--- a/setup.py
+++ b/setup.py
@@ -66,12 +66,5 @@ setup(
     include_package_data=True,
     long_description_content_type="text/markdown",
     install_requires=REQUIREMENTS,
-    entry_points={
-        "console_scripts": [
-            "vizmap=hicstuff.vizmap:main",
-            "fraglist=hicstuff.fraglist:main",
-            "iteralign=hicstuff.iteralign:main",
-            "filter3C=hicstuff.filter3C:main",
-        ]
-    },
+    entry_points={"console_scripts": ["hicstuff=hicstuff.main:main"]},
 )


### PR DESCRIPTION
Rework hicstuff to allow performing each task individually by calling subcommands in the format hicstuff <subcommand> <args>. Yahcp itself is used as a subcommand named pipeline. All argument parsing is now done via docopt. README updated accordingly.