### PR TITLE
add prefix to fig_dir

### DIFF
--- a/hicstuff/pipeline.py
+++ b/hicstuff/pipeline.py
@@ -607,15 +607,18 @@ def full_pipeline(
 
     # Define figures output paths
     if plot:
-        if prefix:
-            fig_dir = join(out_dir, prefix + "_plots")
-        else:
-            fig_dir = join(out_dir, "plots")
+        fig_dir = join(out_dir, "plots")
         os.makedirs(fig_dir, exist_ok=True)
-        frag_plot = join(fig_dir, "frags_hist.pdf")
-        dist_plot = join(fig_dir, "event_distance.pdf")
-        pie_plot = join(fig_dir, "event_distribution.pdf")
-        distance_law_plot = join(fig_dir, "distance_law.pdf")
+        if prefix:
+            frag_plot = join(fig_dir, prefix + "_frags_hist.pdf")
+            dist_plot = join(fig_dir, prefix + "_event_distance.pdf")
+            pie_plot = join(fig_dir, prefix + "_event_distribution.pdf")
+            distance_law_plot = join(fig_dir, prefix + "_distance_law.pdf")
+        else:
+            frag_plot = join(fig_dir, "frags_hist.pdf")
+            dist_plot = join(fig_dir, "event_distance.pdf")
+            pie_plot = join(fig_dir, "event_distribution.pdf")
+            distance_law_plot = join(fig_dir, "distance_law.pdf")
         matplotlib.use("Agg")
     else:
         fig_dir = None

--- a/hicstuff/pipeline.py
+++ b/hicstuff/pipeline.py
@@ -607,7 +607,10 @@ def full_pipeline(
 
     # Define figures output paths
     if plot:
-        fig_dir = join(out_dir, "plots")
+        if prefix:
+            fig_dir = join(out_dir, prefix + "_plots")
+        else:
+            fig_dir = join(out_dir, "plots")
         os.makedirs(fig_dir, exist_ok=True)
         frag_plot = join(fig_dir, "frags_hist.pdf")
         dist_plot = join(fig_dir, "event_distance.pdf")


### PR DESCRIPTION
If hicstuff is ran in parallel with the same outdir for several samples (with prefix for each sample), the latest command overwrite pre-existing figures (in fig_dir). To solve this, prefix can be added to the fig_dir (if available).