### PR TITLE
Small fix stats.py

### DIFF
--- a/hicstuff/stats.py
+++ b/hicstuff/stats.py
@@ -45,7 +45,7 @@ def get_pipeline_stats(log_file):
     
     # 2. Number (% of total) of (un)mapped reads
     tot_mapped = [s for s in log_lines if re.search("mapped with Q ", s)][0]
-    tot_mapped = re.sub(".*Q >= 30 \(", "", tot_mapped)
+    tot_mapped = re.sub(".*Q >= \d+ \(", "", tot_mapped)
     tot_mapped = re.sub("/.*", "", tot_mapped)
     tot_mapped = int(float(tot_mapped))
     tot_unmapped = fastq_pairs*2 - tot_mapped


### PR DESCRIPTION
Hi,

Here a very small fix to allow other Q filters (other than 30, default min_qual in full_pipeline) in the stats.py. 

In the case Q != 30, re.sub wasn't able to find the corresponding substring in the log, leading to a conversion error from string to int in the following line. 

kind regards,

Nicolas